### PR TITLE
Allow string literals to be used as `cty.Values`

### DIFF
--- a/hclwrite/generate.go
+++ b/hclwrite/generate.go
@@ -5,6 +5,7 @@ package hclwrite
 
 import (
 	"fmt"
+	"reflect"
 	"unicode"
 	"unicode/utf8"
 
@@ -182,6 +183,23 @@ func TokensForFunctionCall(funcName string, args ...Tokens) Tokens {
 	return toks
 }
 
+func RawStringVal(s string) cty.Value {
+	return rawTokensCapsule(Tokens{
+		&Token{
+			Type:  hclsyntax.TokenOQuote,
+			Bytes: []byte{'"'},
+		},
+		&Token{
+			Type:  hclsyntax.TokenQuotedLit,
+			Bytes: []byte(s),
+		},
+		&Token{
+			Type:  hclsyntax.TokenCQuote,
+			Bytes: []byte{'"'},
+		},
+	})
+}
+
 func appendTokensForValue(val cty.Value, toks Tokens) Tokens {
 	switch {
 
@@ -296,6 +314,15 @@ func appendTokensForValue(val cty.Value, toks Tokens) Tokens {
 			Type:  hclsyntax.TokenCBrace,
 			Bytes: []byte{'}'},
 		})
+
+	case val.Type().IsCapsuleType() && val.Type().EncapsulatedType() == reflect.TypeOf(Tokens{}):
+		data := val.Type().CapsuleExtensionData(rawTokensKey)
+		if data != nil {
+			if rawTokens, ok := data.(Tokens); ok {
+				toks = append(toks, rawTokens...)
+				return toks
+			}
+		}
 
 	default:
 		panic(fmt.Sprintf("cannot produce tokens for %#v", val))

--- a/hclwrite/generate_test.go
+++ b/hclwrite/generate_test.go
@@ -105,6 +105,23 @@ func TestTokensForValue(t *testing.T) {
 			},
 		},
 		{
+			RawStringVal(`^\d+\.\d+\.\d+$`),
+			Tokens{
+				{
+					Type:  hclsyntax.TokenOQuote,
+					Bytes: []byte(`"`),
+				},
+				{
+					Type:  hclsyntax.TokenQuotedLit,
+					Bytes: []byte(`^\d+\.\d+\.\d+$`),
+				},
+				{
+					Type:  hclsyntax.TokenCQuote,
+					Bytes: []byte(`"`),
+				},
+			},
+		},
+		{
 			cty.StringVal(`"foo"`),
 			Tokens{
 				{

--- a/hclwrite/raw_tokens_capsule.go
+++ b/hclwrite/raw_tokens_capsule.go
@@ -1,0 +1,33 @@
+package hclwrite
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+type rawTokensValue struct{}
+
+var rawTokensKey = rawTokensValue{}
+
+func rawTokensCapsule(tokens Tokens) cty.Value {
+	ty := cty.CapsuleWithOps("RawTokens", reflect.TypeOf(Tokens{}), &cty.CapsuleOps{
+		GoString: func(v interface{}) string {
+			iPtr := v.(*Tokens)
+			return fmt.Sprintf("RawTokens(%#v)", *iPtr)
+		},
+		TypeGoString: func(ty reflect.Type) string {
+			return fmt.Sprintf("RawTokens(%s)", ty)
+		},
+		ExtensionData: func(key interface{}) interface{} {
+			if key == rawTokensKey {
+				return tokens
+			}
+
+			return nil
+		},
+	})
+
+	return cty.CapsuleVal(ty, &tokens)
+}


### PR DESCRIPTION
@arminbuerkle PTAL. We'd like to (eventually) upstream it to fix https://github.com/hashicorp/hcl/issues/302.

I'm not happy with the code yet.